### PR TITLE
Add traits support

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,4 +4,7 @@ import RxTimelaneTests
 
 var tests = [XCTestCaseEntry]()
 tests += RxTimelaneTests.allTests()
+tests += RxSingleTimelaneTests.allTests()
+tests += RxCompletableTimelaneTests.allTests()
+tests += RxMaybeTimelaneTests.allTests()
 XCTMain(tests)

--- a/Tests/RxTimelaneTests/RxCompletableTimelaneTests.swift
+++ b/Tests/RxTimelaneTests/RxCompletableTimelaneTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import TimelaneCore
+import TimelaneCoreTestUtils
+import RxSwift
+@testable import RxTimelane
+
+final class RxCompletableTimelaneTests: XCTestCase {
+    /// Test the events emitted by a sync integer single
+    func testEmitsEventsFromCompletingCompletable() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+                
+        _ = Completable.empty()
+            .lane("Test Subscription", filter: [.event], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertEqual(recorder.logged.count, 1)
+        guard recorder.logged.count == 1 else {
+            return
+        }
+        
+        XCTAssertEqual(recorder.logged[0].outputTldr, "Completed, Test Subscription, ")
+
+        XCTAssertEqual(recorder.logged[0].type, "Completed")
+        XCTAssertEqual(recorder.logged[0].subscription, "Test Subscription")
+    }
+
+    enum TestError: LocalizedError {
+        case test
+        var errorDescription: String? {
+            return "Error description"
+        }
+    }
+
+    /// Test error event
+    func testEmitsEventsFromFailedCompletable() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Completable.error(TestError.test)
+            .lane("Test Subscription", filter: [.event], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 1)
+        guard recorder.logged.count == 1 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].type, "Error")
+        XCTAssertEqual(recorder.logged[0].value, "Error description")
+    }
+
+    /// Test subscription
+    func testEmitsSubscription() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Completable.empty()
+            .lane("Test Subscription", filter: [.subscription], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].signpostType, "begin")
+        XCTAssertEqual(recorder.logged[0].subscribe, "Test Subscription")
+
+        XCTAssertEqual(recorder.logged[1].signpostType, "end")
+    }
+
+    /// Test formatting
+    func testFormatting() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Single.just(3)
+            .lane("Test Subscription", filter: [.event], transformValue: { _ in return "TEST" }, logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].outputTldr, "Output, Test Subscription, TEST")
+    }
+    
+    static var allTests = [
+        ("testEmitsEventsFromCompletingCompletable", testEmitsEventsFromCompletingCompletable),
+        ("testEmitsEventsFromFailedCompletable", testEmitsEventsFromFailedCompletable),
+        ("testEmitsSubscription", testEmitsSubscription),
+        ("testFormatting", testFormatting),
+    ]
+}

--- a/Tests/RxTimelaneTests/RxMaybeTimelaneTests.swift
+++ b/Tests/RxTimelaneTests/RxMaybeTimelaneTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import TimelaneCore
+import TimelaneCoreTestUtils
+import RxSwift
+@testable import RxTimelane
+
+final class RxMaybeTimelaneTests: XCTestCase {
+    /// Test the events emitted by a sync integer single
+    func testEmitsEventsFromCompletingMaybe() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+        let value = 3
+        
+        _ = Maybe.just(value)
+            .lane("Test Subscription", filter: [.event], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+        
+        XCTAssertEqual(recorder.logged[0].outputTldr, "Output, Test Subscription, \(value)")
+        XCTAssertEqual(recorder.logged[1].outputTldr, "Completed, Test Subscription, ")
+
+        XCTAssertEqual(recorder.logged[1].type, "Completed")
+        XCTAssertEqual(recorder.logged[1].subscription, "Test Subscription")
+    }
+
+    enum TestError: LocalizedError {
+        case test
+        var errorDescription: String? {
+            return "Error description"
+        }
+    }
+
+    /// Test error event
+    func testEmitsEventsFromFailedMaybe() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Maybe<Int>.error(TestError.test)
+            .lane("Test Subscription", filter: [.event], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 1)
+        guard recorder.logged.count == 1 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].type, "Error")
+        XCTAssertEqual(recorder.logged[0].value, "Error description")
+    }
+
+    /// Test subscription
+    func testEmitsSubscription() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Single.just(3)
+            .lane("Test Subscription", filter: [.subscription], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].signpostType, "begin")
+        XCTAssertEqual(recorder.logged[0].subscribe, "Test Subscription")
+
+        XCTAssertEqual(recorder.logged[1].signpostType, "end")
+    }
+
+    /// Test formatting
+    func testFormatting() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Single.just(3)
+            .lane("Test Subscription", filter: [.event], transformValue: { _ in return "TEST" }, logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].outputTldr, "Output, Test Subscription, TEST")
+    }
+    
+    static var allTests = [
+        ("testEmitsEventsFromCompletingMaybe", testEmitsEventsFromCompletingMaybe),
+        ("testEmitsEventsFromFailedMaybe", testEmitsEventsFromFailedMaybe),
+        ("testEmitsSubscription", testEmitsSubscription),
+        ("testFormatting", testFormatting),
+    ]
+}

--- a/Tests/RxTimelaneTests/RxSingleTimelaneTests.swift
+++ b/Tests/RxTimelaneTests/RxSingleTimelaneTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import TimelaneCore
+import TimelaneCoreTestUtils
+import RxSwift
+@testable import RxTimelane
+
+final class RxSingleTimelaneTests: XCTestCase {
+    /// Test the events emitted by a sync integer single
+    func testEmitsEventsFromCompletingSingle() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+        let value = 3
+        
+        _ = Single.just(value)
+            .lane("Test Subscription", filter: [.event], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+        
+        XCTAssertEqual(recorder.logged[0].outputTldr, "Output, Test Subscription, \(value)")
+        XCTAssertEqual(recorder.logged[1].outputTldr, "Completed, Test Subscription, ")
+
+        XCTAssertEqual(recorder.logged[1].type, "Completed")
+        XCTAssertEqual(recorder.logged[1].subscription, "Test Subscription")
+    }
+
+    enum TestError: LocalizedError {
+        case test
+        var errorDescription: String? {
+            return "Error description"
+        }
+    }
+
+    /// Test error event
+    func testEmitsEventsFromFailedSingle() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Single<Int>.error(TestError.test)
+            .lane("Test Subscription", filter: [.event], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 1)
+        guard recorder.logged.count == 1 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].type, "Error")
+        XCTAssertEqual(recorder.logged[0].value, "Error description")
+    }
+
+    /// Test subscription
+    func testEmitsSubscription() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Single.just(3)
+            .lane("Test Subscription", filter: [.subscription], logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].signpostType, "begin")
+        XCTAssertEqual(recorder.logged[0].subscribe, "Test Subscription")
+
+        XCTAssertEqual(recorder.logged[1].signpostType, "end")
+    }
+
+    /// Test formatting
+    func testFormatting() {
+        let recorder = TestLog()
+        Timelane.Subscription.didEmitVersion = true
+
+        let cancellable = Single.just(3)
+            .lane("Test Subscription", filter: [.event], transformValue: { _ in return "TEST" }, logger: recorder.log)
+            .subscribe { _ in }
+
+        XCTAssertNotNil(cancellable)
+
+        XCTAssertEqual(recorder.logged.count, 2)
+        guard recorder.logged.count == 2 else {
+            return
+        }
+
+        XCTAssertEqual(recorder.logged[0].outputTldr, "Output, Test Subscription, TEST")
+    }
+    
+    static var allTests = [
+        ("testEmitsEventsFromCompletingSingle", testEmitsEventsFromCompletingSingle),
+        ("testEmitsEventsFromFailedSingle", testEmitsEventsFromFailedSingle),
+        ("testEmitsSubscription", testEmitsSubscription),
+        ("testFormatting", testFormatting),
+    ]
+}

--- a/Tests/RxTimelaneTests/RxTimelaneTests.swift
+++ b/Tests/RxTimelaneTests/RxTimelaneTests.swift
@@ -4,7 +4,7 @@ import TimelaneCoreTestUtils
 import RxSwift
 @testable import RxTimelane
 
-final class TimelaneCombineTests: XCTestCase {
+final class RxTimelaneTests: XCTestCase {
     /// Test the events emitted by a sync array publisher
     func testEmitsEventsFromCompletingPublisher() {
         let recorder = TestLog()

--- a/Tests/RxTimelaneTests/XCTestManifests.swift
+++ b/Tests/RxTimelaneTests/XCTestManifests.swift
@@ -4,6 +4,9 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(RxTimelaneTests.allTests),
+        testCase(RxSingleTimelaneTests.allTests),
+        testCase(RxCompletableTimelaneTests.allTests),
+        testCase(RxMaybeTimelaneTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
Currently RxTimelane only supports observables so I added extensions also for Single, Maybe and Completable so it supports all the RxSwift traits. I tried to match the same code style.

- Added tests for all the traits
- Used the logger parameter (But I guess it's missing a default otherwise it'll break the API)